### PR TITLE
Added bug report, feature req & blank issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.md
@@ -1,0 +1,41 @@
+---
+name: Bug report
+about: File a bug report to help us resolve your issue
+title: ""
+labels: "Type: Bug,Status: Pending"
+assignees: "kasperhesthaven"
+---
+
+<!--This is just a template - feel free to delete any and all of it and replace as appropriate.-->
+
+### Summary
+
+<!--
+* Please share a quick summary of the issue you're facing.
+* What behavior are you seeing, and what behavior were you expecting?
+  -->
+
+### Steps to reproduce
+
+<!--
+* If possible include steps to reproduce the issue.
+  -->
+
+### Expected results
+
+<!--
+* What behavior were you expecting?
+  -->
+
+### Actual results
+
+<!--
+* What behavior happened instead?
+  -->
+
+### Configuration
+
+<!--
+* In which environment did the issue occur?
+* Which version of the project, on what OS, in what browser, etc.
+  -->

--- a/.github/ISSUE_TEMPLATE/02_feature_request.md
+++ b/.github/ISSUE_TEMPLATE/02_feature_request.md
@@ -1,0 +1,25 @@
+---
+name: Feature request
+about: Propose a new feature or change to the project
+title: ""
+labels: "Status: Pending,Type: Feature"
+assignees: "kasperhesthaven"
+---
+
+## Description
+
+<!--
+Please describe the general purpose and value of the feature request or change you'd like to see.
+-->
+
+## Usage Example
+
+<!--
+Please provide an example scenario that demonstrates the value of the request.
+-->
+
+## Risks
+
+<!--
+Please mention any risks that to your knowledge the feature request might entail, such as breaking changes, performance regressions, etc.
+-->

--- a/.github/ISSUE_TEMPLATE/03_blank.md
+++ b/.github/ISSUE_TEMPLATE/03_blank.md
@@ -1,0 +1,7 @@
+---
+name: Blank issue
+about: Something that doesn't fit the other categories
+title: ""
+labels: "Status: Pending"
+assignees: "kasperhesthaven"
+---


### PR DESCRIPTION
## Purpose

Without templates there's a higher cognitive load to creating issues and higher risk of inconsistencies in the quality.

## Approach

I've added 3 initial templates covering the most common cases:

- Bug/error report
- Feature request
- Blank, for anything else

## Learning

The templates are inspired by the dotnet team's setup.